### PR TITLE
Fix Merchant AI

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Aims to backport [FarmingForBlockheads](https://www.curseforge.com/minecraft/mc-
 
 ## What doesn't work:
 - ~~NPC doesn't have a proper model/texture.~~
-- AI is broken.
+- ~~AI is broken.~~
 - No sound effects.
 - No particle effects.
 - ~~Block doesn't rotate to face the player when placed.~~

--- a/src/main/java/com/guigs44/farmingforengineers/CommonProxy.java
+++ b/src/main/java/com/guigs44/farmingforengineers/CommonProxy.java
@@ -1,6 +1,7 @@
 package com.guigs44.farmingforengineers;
 
 import com.guigs44.farmingforengineers.block.BlockMarket;
+import com.guigs44.farmingforengineers.block.ModBlocks;
 import com.guigs44.farmingforengineers.item.ItemBlockMarket;
 import com.guigs44.farmingforengineers.network.GuiHandler;
 import com.guigs44.farmingforengineers.tile.TileMarket;
@@ -17,8 +18,8 @@ public class CommonProxy {
     }
 
     public void init(FMLInitializationEvent event) {
-        FarmingForEngineers.blockMarket = new BlockMarket();
-        GameRegistry.registerBlock(FarmingForEngineers.blockMarket, ItemBlockMarket.class, "market");
+        ModBlocks.market = new BlockMarket();
+        GameRegistry.registerBlock(ModBlocks.market, ItemBlockMarket.class, "market");
         NetworkRegistry.INSTANCE.registerGuiHandler(FarmingForEngineers.instance, new GuiHandler());
         GameRegistry.registerTileEntity(TileMarket.class, FarmingForEngineers.MOD_ID + ":market");
     }

--- a/src/main/java/com/guigs44/farmingforengineers/FarmingForEngineers.java
+++ b/src/main/java/com/guigs44/farmingforengineers/FarmingForEngineers.java
@@ -3,7 +3,6 @@ package com.guigs44.farmingforengineers;
 import java.io.File;
 import java.util.Optional;
 
-import net.minecraft.block.Block;
 import net.minecraft.creativetab.CreativeTabs;
 import net.minecraft.item.Item;
 import net.minecraftforge.common.config.Configuration;
@@ -11,6 +10,7 @@ import net.minecraftforge.common.config.Configuration;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
+import com.guigs44.farmingforengineers.block.ModBlocks;
 import com.guigs44.farmingforengineers.compat.Compat;
 import com.guigs44.farmingforengineers.compat.VanillaAddon;
 import com.guigs44.farmingforengineers.entity.EntityMerchant;
@@ -55,13 +55,11 @@ public class FarmingForEngineers {
 
         @Override
         public Item getTabIconItem() {
-            return Item.getItemFromBlock(FarmingForEngineers.blockMarket);
+            return Item.getItemFromBlock(ModBlocks.market);
         }
     };
 
     public static File configDir;
-
-    public static Block blockMarket;
 
     @Mod.EventHandler
     public void preInit(FMLPreInitializationEvent event) {

--- a/src/main/java/com/guigs44/farmingforengineers/ModRecipes.java
+++ b/src/main/java/com/guigs44/farmingforengineers/ModRecipes.java
@@ -3,13 +3,15 @@ package com.guigs44.farmingforengineers;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 
+import com.guigs44.farmingforengineers.block.ModBlocks;
+
 import cpw.mods.fml.common.registry.GameRegistry;
 
 public class ModRecipes {
 
     public static void init() {
         GameRegistry.addRecipe(
-                new ItemStack(FarmingForEngineers.blockMarket),
+                new ItemStack(ModBlocks.market),
                 "PCP",
                 "W W",
                 "WWW",

--- a/src/main/java/com/guigs44/farmingforengineers/block/BlockMarket.java
+++ b/src/main/java/com/guigs44/farmingforengineers/block/BlockMarket.java
@@ -174,6 +174,6 @@ public class BlockMarket extends BlockContainer {
     @Override
     public void onBlockDestroyedByPlayer(World p_149664_1_, int p_149664_2_, int p_149664_3_, int p_149664_4_,
             int p_149664_5_) {
-        merchant.disappear();
+        if (merchant != null) merchant.disappear();
     }
 }

--- a/src/main/java/com/guigs44/farmingforengineers/block/BlockMarket.java
+++ b/src/main/java/com/guigs44/farmingforengineers/block/BlockMarket.java
@@ -2,6 +2,7 @@ package com.guigs44.farmingforengineers.block;
 
 import net.minecraft.block.Block;
 import net.minecraft.block.BlockContainer;
+import net.minecraft.block.BlockPistonBase;
 import net.minecraft.block.material.Material;
 import net.minecraft.client.renderer.texture.IIconRegister;
 import net.minecraft.entity.EntityLivingBase;
@@ -9,10 +10,9 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.init.Blocks;
 import net.minecraft.item.ItemStack;
 import net.minecraft.tileentity.TileEntity;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.util.IIcon;
-import net.minecraft.util.MathHelper;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.guigs44.farmingforengineers.FarmingForEngineers;
 import com.guigs44.farmingforengineers.client.render.block.MarketBlockRenderer;
@@ -72,24 +72,17 @@ public class BlockMarket extends BlockContainer {
 
     @Override
     public void onBlockPlacedBy(World world, int x, int y, int z, EntityLivingBase placer, ItemStack itemStack) {
-        int facing = MathHelper.floor_double(placer.rotationYaw * 4.0F / 360.0F + 0.5D) & 3;
-        switch (facing) {
-            case 0:
-                world.setBlockMetadataWithNotify(x, y, z, 2, 2);
-                break;
-            case 1:
-                world.setBlockMetadataWithNotify(x, y, z, 5, 2);
-                break;
-            case 2:
-                world.setBlockMetadataWithNotify(x, y, z, 3, 2);
-                break;
-            case 3:
-                world.setBlockMetadataWithNotify(x, y, z, 4, 2);
-                break;
-        }
+        // See BlockDispenser#onBlockPlacedBy
+        int meta = BlockPistonBase.determineOrientation(world, x, y, z, placer);
+        world.setBlockMetadataWithNotify(x, y, z, meta, 2);
+        ForgeDirection facing = ForgeDirection.getOrientation(meta); // facing metadata value -> EnumFacing value
+        ForgeDirection merchantFacing = facing.getOpposite();
 
-        // EnumFacing facing = EnumFacing.NORTH;
-        // BlockPos entityPos = pos.offset(facing.getOpposite());
+        // The position of the merchant entity
+        int merchantX = x + merchantFacing.offsetX;
+        int merchantY = y;
+        int merchantZ = z + merchantFacing.offsetZ;
+
         EntityMerchant.SpawnAnimationType spawnAnimationType = EntityMerchant.SpawnAnimationType.MAGIC;
         if (world.canBlockSeeTheSky(x, y, z)) {
             spawnAnimationType = EntityMerchant.SpawnAnimationType.FALLING;
@@ -98,27 +91,27 @@ public class BlockMarket extends BlockContainer {
         }
         if (!world.isRemote) {
             merchant = new EntityMerchant(world);
-            merchant.setMarket(x, y, z, EnumFacing.NORTH);
+            merchant.setMarket(x, y, z, facing);
             merchant.setToFacingAngle();
             merchant.setSpawnAnimation(spawnAnimationType);
 
-            if (world.canBlockSeeTheSky(x, y, z)) {
-                merchant.setPosition(x + 0.5, y + 172, z + 0.5);
-            } else if (!world.isAirBlock(x, y, z - 1)) {
-                merchant.setPosition(x + 0.5, y + 0.5, z + 0.5);
+            if (world.canBlockSeeTheSky(merchantX, merchantY, merchantZ)) {
+                merchant.setPosition(merchantX + 0.5, merchantY + 172, merchantZ + 0.5);
+            } else if (!world.isAirBlock(merchantX, merchantY, merchantZ - 1)) {
+                merchant.setPosition(merchantX + 0.5, merchantY + 0.5, merchantZ + 0.5);
             } else {
-                merchant.setPosition(x + 0.5, y, z + 0.5);
+                merchant.setPosition(merchantX + 0.5, merchantY, merchantZ + 0.5);
             }
 
             world.spawnEntityInWorld(merchant);
             merchant.onInitialSpawn(null);
         }
         if (spawnAnimationType == EntityMerchant.SpawnAnimationType.FALLING) {
-            world.playSound(x + 0.5, y + 1, z + 0.5, "sounds.falling", 1f, 1f, false);
+            world.playSound(merchantX + 0.5, merchantY + 1, merchantZ + 0.5, "sounds.falling", 1f, 1f, false);
         } else if (spawnAnimationType == EntityMerchant.SpawnAnimationType.DIGGING) {
-            world.playSound(x + 0.5, y + 1, z, "sounds.falling", 1f, 1f, false);
+            world.playSound(merchantX + 0.5, merchantY + 1, merchantZ, "sounds.falling", 1f, 1f, false);
         } else {
-            world.playSound(x + 0.5, y + 1, z + 0.5, "item.firecharge.use", 1f, 1f, false);
+            world.playSound(merchantX + 0.5, merchantY + 1, merchantZ + 0.5, "item.firecharge.use", 1f, 1f, false);
             for (int i = 0; i < 50; i++) {
                 world.spawnParticle(
                         "firework",
@@ -129,7 +122,7 @@ public class BlockMarket extends BlockContainer {
                         (Math.random() - 0.5) * 0.5f,
                         (Math.random() - 0.5) * 0.5f);
             }
-            world.spawnParticle("explosion", x + 0.5, y + 1, z + 0.5, 0, 0, 0);
+            world.spawnParticle("explosion", merchantX + 0.5, merchantY + 1, merchantZ + 0.5, 0, 0, 0);
         }
     }
 

--- a/src/main/java/com/guigs44/farmingforengineers/entity/EntityAIMerchant.java
+++ b/src/main/java/com/guigs44/farmingforengineers/entity/EntityAIMerchant.java
@@ -23,9 +23,9 @@ public class EntityAIMerchant extends EntityAIBase {
             return false;
         }
         if (true) { // TODO: Check if location is valid
-            this.movePosX = entity.posX + 0.5;
-            this.movePosY = entity.posY + 1;
-            this.movePosZ = entity.posZ + 0.5;
+            this.movePosX = entity.marketX;
+            this.movePosY = entity.marketY;
+            this.movePosZ = entity.marketZ;
             return true;
         }
         return false;

--- a/src/main/java/com/guigs44/farmingforengineers/entity/EntityAIMerchant.java
+++ b/src/main/java/com/guigs44/farmingforengineers/entity/EntityAIMerchant.java
@@ -1,6 +1,7 @@
 package com.guigs44.farmingforengineers.entity;
 
 import net.minecraft.entity.ai.EntityAIBase;
+import net.minecraftforge.common.util.ForgeDirection;
 
 public class EntityAIMerchant extends EntityAIBase {
 
@@ -22,13 +23,12 @@ public class EntityAIMerchant extends EntityAIBase {
             entity.setToFacingAngle();
             return false;
         }
-        if (true) { // TODO: Check if location is valid
-            this.movePosX = entity.marketX;
-            this.movePosY = entity.marketY;
-            this.movePosZ = entity.marketZ;
-            return true;
-        }
-        return false;
+
+        ForgeDirection opposite = entity.facing.getOpposite();
+        this.movePosX = entity.marketX + opposite.offsetX;
+        this.movePosY = entity.marketY;
+        this.movePosZ = entity.marketZ + opposite.offsetY;
+        return true;
     }
 
     @Override

--- a/src/main/java/com/guigs44/farmingforengineers/entity/EntityMerchant.java
+++ b/src/main/java/com/guigs44/farmingforengineers/entity/EntityMerchant.java
@@ -4,6 +4,7 @@ import java.util.Random;
 
 import javax.annotation.Nullable;
 
+import net.minecraft.block.Block;
 import net.minecraft.entity.EntityCreature;
 import net.minecraft.entity.IEntityLivingData;
 import net.minecraft.entity.INpc;
@@ -12,6 +13,7 @@ import net.minecraft.entity.ai.EntityAIAvoidEntity;
 import net.minecraft.entity.ai.EntityAISwimming;
 import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
+import net.minecraft.init.Blocks;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
 import net.minecraft.world.World;
@@ -226,7 +228,11 @@ public class EntityMerchant extends EntityCreature implements INpc {
     }
 
     private boolean isMarketValid() {
-        return worldObj.getBlock(marketX, marketY, marketZ) == ModBlocks.market;
+        Block block = worldObj.getBlock(marketX, marketY, marketZ);
+        // While loading a world, getBlock() will return bedrock for a few ticks until everything
+        // gets fully initialized. Consider that to be valid so that the merchant doesn't disappear
+        // every load.
+        return block == ModBlocks.market || block == Blocks.bedrock;
     }
 
     public void setToFacingAngle() {

--- a/src/main/java/com/guigs44/farmingforengineers/entity/EntityMerchant.java
+++ b/src/main/java/com/guigs44/farmingforengineers/entity/EntityMerchant.java
@@ -22,6 +22,11 @@ import com.guigs44.farmingforengineers.network.GuiHandler;
 
 public class EntityMerchant extends EntityCreature implements INpc {
 
+    /**
+     * The minimum distance <em>squared</em> at which the merchant should be considered 'at' the market.
+     */
+    public static final float MARKET_ARRIVAL_DISTANCE = 1f;
+
     public enum SpawnAnimationType {
         MAGIC,
         FALLING,
@@ -33,9 +38,9 @@ public class EntityMerchant extends EntityCreature implements INpc {
             "Weathered Salesperson" };
 
     // private BlockPos marketPos;
-    private int marketX;
-    private int marketY;
-    private int marketZ;
+    int marketX;
+    int marketY;
+    int marketZ;
     private EnumFacing facing;
     private boolean spawnDone;
     private SpawnAnimationType spawnAnimation = SpawnAnimationType.MAGIC;
@@ -50,6 +55,11 @@ public class EntityMerchant extends EntityCreature implements INpc {
         this.tasks.addTask(0, new EntityAISwimming(this));
         this.tasks.addTask(1, new EntityAIAvoidEntity(this, EntityZombie.class, 8f, 0.6, 0.6));
         this.tasks.addTask(5, new EntityAIMerchant(this, 0.6));
+    }
+
+    @Override
+    protected boolean isAIEnabled() {
+        return true;
     }
 
     @Override
@@ -217,9 +227,7 @@ public class EntityMerchant extends EntityCreature implements INpc {
     // }
 
     public boolean isAtMarket() {
-        // TODO: Implement
-        // return marketEntityPos != null && getDistanceSq(marketEntityPos.offset(facing.getOpposite())) <= 1;
-        return true;
+        return getDistanceSq(marketX, marketY, marketZ) <= MARKET_ARRIVAL_DISTANCE;
     }
 
     private boolean isMarketValid() {

--- a/src/main/java/com/guigs44/farmingforengineers/entity/EntityMerchant.java
+++ b/src/main/java/com/guigs44/farmingforengineers/entity/EntityMerchant.java
@@ -14,18 +14,20 @@ import net.minecraft.entity.monster.EntityZombie;
 import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.nbt.NBTTagCompound;
 import net.minecraft.util.DamageSource;
-import net.minecraft.util.EnumFacing;
 import net.minecraft.world.World;
+import net.minecraftforge.common.util.ForgeDirection;
 
 import com.guigs44.farmingforengineers.FarmingForEngineers;
+import com.guigs44.farmingforengineers.block.ModBlocks;
 import com.guigs44.farmingforengineers.network.GuiHandler;
+import com.guigs44.farmingforengineers.utilities.RenderUtils;
 
 public class EntityMerchant extends EntityCreature implements INpc {
 
     /**
      * The minimum distance <em>squared</em> at which the merchant should be considered 'at' the market.
      */
-    public static final float MARKET_ARRIVAL_DISTANCE = 1f;
+    public static final float MARKET_ARRIVAL_DISTANCE = 1.75f * 1.75f;
 
     public enum SpawnAnimationType {
         MAGIC,
@@ -41,11 +43,10 @@ public class EntityMerchant extends EntityCreature implements INpc {
     int marketX;
     int marketY;
     int marketZ;
-    private EnumFacing facing;
+    ForgeDirection facing;
     private boolean spawnDone;
     private SpawnAnimationType spawnAnimation = SpawnAnimationType.MAGIC;
 
-    // private BlockPos marketEntityPos;
     private int diggingAnimation;
     // private IBlockState diggingBlockState;
 
@@ -110,7 +111,7 @@ public class EntityMerchant extends EntityCreature implements INpc {
             setCustomNameTag(NAMES[rand.nextInt(NAMES.length)]);
         }
         if (compound.hasKey("MarketPosX")) {
-            setMarket(marketX, marketY, marketZ, EnumFacing.getFront(compound.getByte("Facing")));
+            setMarket(marketX, marketY, marketZ, ForgeDirection.getOrientation(compound.getByte("Facing")));
         }
         spawnDone = compound.getBoolean("SpawnDone");
         spawnAnimation = SpawnAnimationType.values()[compound.getByte("SpawnAnimation")];
@@ -213,30 +214,23 @@ public class EntityMerchant extends EntityCreature implements INpc {
     // return false;
     // }
 
-    public void setMarket(int marketX, int marketY, int marketZ, EnumFacing facing) {
+    public void setMarket(int marketX, int marketY, int marketZ, ForgeDirection facing) {
         this.marketX = marketX;
         this.marketY = marketY;
         this.marketZ = marketZ;
-        // this.marketEntityPos = marketPos.offset(facing.getOpposite());
         this.facing = facing;
     }
-
-    // @Nullable
-    // public BlockPos getMarketEntityPosition() {
-    // return marketEntityPos;
-    // }
 
     public boolean isAtMarket() {
         return getDistanceSq(marketX, marketY, marketZ) <= MARKET_ARRIVAL_DISTANCE;
     }
 
     private boolean isMarketValid() {
-        // return marketPos != null && worldObj.getBlockState(marketPos).getBlock() == ModBlocks.market;
-        return true;
+        return worldObj.getBlock(marketX, marketY, marketZ) == ModBlocks.market;
     }
 
     public void setToFacingAngle() {
-        float facingAngle = 0f; // facing.getHorizontalAngle();
+        float facingAngle = RenderUtils.getAngle(facing);
         setRotation(facingAngle, 0f);
         setRotationYawHead(facingAngle);
         // setRenderYawOffset(facingAngle);

--- a/src/main/java/com/guigs44/farmingforengineers/utilities/RenderUtils.java
+++ b/src/main/java/com/guigs44/farmingforengineers/utilities/RenderUtils.java
@@ -5,13 +5,17 @@ import net.minecraftforge.common.util.ForgeDirection;
 public class RenderUtils {
 
     public static float getAngle(int metadata) {
-        switch (ForgeDirection.getOrientation(metadata)) {
+        return getAngle(ForgeDirection.getOrientation(metadata));
+    }
+
+    public static float getAngle(ForgeDirection direction) {
+        switch (direction) {
             case NORTH:
-                return 0;
+                return 180;
             case EAST:
                 return -90;
             case SOUTH:
-                return 180;
+                return 0;
             case WEST:
                 return 90;
             default:


### PR DESCRIPTION
This fixes the AI and the merchant NPC's spawn location.

The merchant will now, in order of priority
1) swim
2) run away from zombies (not all mobs, just zombies)
3) path towards, and stand behind the associated market

This is much uglier than it was in the original mod due to the lack of a nice `BlockPos` like structure/API, but it seems to work from my testing. ~~This does introduce one issue, though, which is that `isMarketValid` seems to borke after reloading the world. Haven't had a chance to dive deep into that yet.~~ (see below)